### PR TITLE
Code coverage available after you do 'npm install -g istanbul'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Code coverage reports should not be committed ever
+tests/coverage

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Checkers game",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start"
+    "test": "./node_modules/karma/bin/karma start",
+    // cd into the './tests' directory before running this command
+    "coverage": "istanbul cover ../node_modules/mocha/bin/_mocha *.js"
   },
   "repository": {
     "type": "git",

--- a/tests/spec.js
+++ b/tests/spec.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
     describe('Some cool stuff', function () {
-        beforeEach(module('checkers'));
+        //beforeEach(module('checkers'));
         it('should do stuff', function(){
 
         });


### PR DESCRIPTION
1. Install istanbul (`npm install -g istanbul`)
2. cd into `./tests` directory
3. execute the following command (`istanbul cover ../node_modules/mocha/bin/_mocha *.js`)
4. `./tests/coverage` folder will be created. In the `lcov-report` folder, there should be an index.html file. Open that in your browser
