### PR TITLE
ensure correct version of nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ jspm_packages
 
 # Code coverage reports should not be committed ever
 tests/coverage
+
+# generated
+.nvmrc

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.0",
   "description": "Checkers game",
   "main": "index.js",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "scripts": {
     "test": "./node_modules/karma/bin/karma start",
-    "deploy": "fly production"
+    "deploy": "fly production",
+    "nvmrc": "echo $(node -p -e 'require(\"./package\").engines.node.split(\">=\").join(\"\")') > .nvmrc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This add an "engines" entry to `package.json`. A `.nvmrc`file can be generated from the entry & the correct version of `node` can be installed from it;

`npm run nvmrc; nvm install; npm install; node server;` 

fixes #80